### PR TITLE
Put VSCode in proper directory

### DIFF
--- a/Build123dPortableSetup.nsi
+++ b/Build123dPortableSetup.nsi
@@ -418,7 +418,7 @@ AddSize 2256000
 
     # Create path if only VScode is to be installed
     ${If} $WinpythonURL_Checkbox == 1
-            StrCpy $VsCodeINSTDIR "$INSTDIR\$PyPath\t"
+            StrCpy $VsCodeINSTDIR "$INSTDIR\$PyPath\t\vscode"
         ${Else}
             StrCpy $VsCodeINSTDIR "$INSTDIR"
     ${EndIf}


### PR DESCRIPTION
per https://github.com/winpython/winpython/blob/bc8dc44d8939ac6f670ec4975780db2b2d567e51/make.py#L1133C1-L1143C3

the winpython script expects VSCode inside a certain subdirectory, this PR fixes that issue

Thanks to @bernhard-42 for the fix and research